### PR TITLE
Support Windows

### DIFF
--- a/confetti/confetti.go
+++ b/confetti/confetti.go
@@ -10,7 +10,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"golang.org/x/term"
 )
 
 const (
@@ -57,14 +56,6 @@ func Spawn(width, height int) []simulation.Particle {
 		particles = append(particles, p)
 	}
 	return particles
-}
-
-func InitialModel() model {
-	width, height, err := term.GetSize(0)
-	if err != nil {
-		panic(err)
-	}
-	return InitialModelWithSize(width, height)
 }
 
 func InitialModelWithSize(width, height int) model {

--- a/confetti/confetti_unix.go
+++ b/confetti/confetti_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package confetti
+
+import (
+	"golang.org/x/term"
+)
+
+func InitialModel() model {
+	width, height, err := term.GetSize(0)
+	if err != nil {
+		panic(err)
+	}
+	return InitialModelWithSize(width, height)
+}

--- a/confetti/confetti_windows.go
+++ b/confetti/confetti_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+package confetti
+
+import (
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+func InitialModel() model {
+	h, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE)
+	if err != nil {
+		panic(err)
+	}
+	width, height, err := term.GetSize(int(h))
+	if err != nil {
+		panic(err)
+	}
+	return InitialModelWithSize(width, height)
+}


### PR DESCRIPTION
Current implementation makes panic on Windows

```
panic: The handle is invalid.

goroutine 1 [running]:
github.com/maaslalani/confetty/confetti.InitialModel()
	C:/Users/mattn/go/src/github.com/maaslalani/confetty/confetti/confetti.go:65 +0xb2
github.com/maaslalani/confetty/cmd.glob..func1(0x66d780?, {0x50bb18?, 0x0?, 0x0?})
	C:/Users/mattn/go/src/github.com/maaslalani/confetty/cmd/root.go:19 +0x19
github.com/spf13/cobra.(*Command).execute(0x66d780, {0xc000052220, 0x0, 0x0})
	C:/Users/mattn/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0x66d780)
	C:/Users/mattn/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	C:/Users/mattn/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/maaslalani/confetty/cmd.Execute()
	C:/Users/mattn/go/src/github.com/maaslalani/confetty/cmd/root.go:50 +0x25
main.main()
	C:/Users/mattn/go/src/github.com/maaslalani/confetty/main.go:8 +0x17
```

Since the `term.GetSize(0)` this 0 is not correct value of standard output handle on Windows.

### Changes Introduced

This change fixes to pass the correct stdout handle.

![screenshot](https://user-images.githubusercontent.com/10111/139895948-78205895-16b6-4e7f-ad16-479d558da3f8.gif)
