### PR TITLE
integrate goreleaser and update readme with installation instructions

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install dependencies
+        run: |
+          go mod download
+          curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+      - name: Test
+        run: |
+          go build
+          ./bin/goreleaser check

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GA_GORELEASER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,41 @@
+project_name: confetty
+
+before:
+  hooks:
+    - go mod download
+
+release:
+  github:
+    owner: maaslalani
+    name: confetty
+
+builds:
+  - main: ./main.go
+    binary: confetty
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+brews:
+  - tap:
+      owner: maaslalani
+      name: homebrew-tap
+    folder: Formula
+    homepage: https://github.com/maaslalani/confetty
+    description:  Confetti in your TTY
+    license: MIT
+
+nfpms:
+  - id: confetty
+    package_name: confetty
+    homepage: https://github.com/maaslalani/confetty
+    description:  Confetti in your TTY
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # ConfeTTY
-https://user-images.githubusercontent.com/42545625/128612977-5d6e0321-9584-48b5-8ff8-dd5b811211d3.mov
+
+![build workflow](https://github.com/maaslalani/confetty/actions/workflows/build.yml/badge.svg)
+
+<https://user-images.githubusercontent.com/42545625/128612977-5d6e0321-9584-48b5-8ff8-dd5b811211d3.mov>
 
 Confetti (or fireworks) inside your terminal.
 
-### Preview
+## Preview
 
 You can quickly preview `confetty` through `ssh` (thanks to [charmbracelet/wish](https://github.com/charmbracelet/wish))
 
@@ -14,25 +17,49 @@ ssh -p 2222 ssh.caarlos0.dev
 ssh -p 2223 ssh.caarlos0.dev
 ```
 
-### Installation
+## Installation
 
-```
+### Using go toolchain
+
+```bash
 go install github.com/maaslalani/confetty
 ```
 
-### Usage
+### Using homebrew
 
+```bash
+brew install maaslalani/tap/confetty
 ```
+
+### Using yum
+
+```bash
+yum install -y <<latest rpm url from releases section>>
+```
+
+### Using apt
+
+```bash
+apt install -y <<latest deb url from releases section>>
+```
+
+### Other platforms
+
+Head over to the [releases section](https://github.com/maaslalani/confetty/releases) and download the binary for your platform.
+
+## Usage
+
+```bash
 confetty
 ```
 
-```
+```bash
 confetty fireworks
 ```
 
 Press any key to cause more confetti / fireworks to appear.
-<kbd>Ctrl-C</kbd> or <kbd>q</kbd> to exit.
+`Ctrl-C` or `q` to exit.
 
-#### Why?
+## Why?
 
 ¯\\\_(ツ)\_/¯


### PR DESCRIPTION
Fixes #12 

Every time you tag a version, artifacts for mac, windows and linux get generated automagically :-) 

Things to do before merge for automated publish of automated taps [homebrew taps](https://brew.sh/)
- Create a new repository titled `homebrew-tap` in your account
- Create a personal access token with push access
- Configure it as a secret environment named GA_GORELEASER_TOKEN
- More info https://goreleaser.com/customization/homebrew/