### PR TITLE
chore: install instructions should specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ssh -p 2223 ssh.caarlos0.dev
 ### Installation
 
 ```
-go install github.com/maaslalani/confetty
+go install github.com/maaslalani/confetty@latest
 ```
 
 ### Usage


### PR DESCRIPTION
`go install` won't work otherwise. `latest` seems good enough for now for this tool.
