### PR TITLE
automatic binary releases

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a basic go-releaser action and a tag from testing. You can run it by creating a 1.0.0 release with the tag I made (or delete the tag and make your own release). The action is pretty much straight from [goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action/), with workflow-dispatch added for manual runs from the actions tab. It runs on every push and every tag event, plus whenever you hit run in the actions tab.